### PR TITLE
Update kdTree.js

### DIFF
--- a/kdTree.js
+++ b/kdTree.js
@@ -302,7 +302,8 @@
         }
       }
 
-      nearestSearch(self.root);
+      if(self.root)
+        nearestSearch(self.root);
 
       result = [];
 


### PR DESCRIPTION
I'm getting this exception and I think it's because I'm searching on an empty tree. Does that seem correct and if so, is this a good solution?

```
TypeError: Cannot read property 'dimension' of null
at nearestSearch (kdTree.js:238:38)
at kdTree.nearest (kdTree.js:306:11)
```