### PR TITLE
0 should be a valid max distance

### DIFF
--- a/kdTree.js
+++ b/kdTree.js
@@ -296,7 +296,7 @@
         }
       }
 
-      if (maxDistance) {
+      if (maxDistance != null) {
         for (i = 0; i < maxNodes; i += 1) {
           bestNodes.push([null, maxDistance]);
         }


### PR DESCRIPTION
Currently a `maxDistance` of `0` is not allowed. 

The `if(maxDistance)` condition will always evaluate to `false` when a `maxDistance` of `0` is specified.

This change allows a `maxDistance` of 0.